### PR TITLE
fix "error: redefinition of typedef ‘domid_t’"

### DIFF
--- a/drivers/xen/vgt/vgt-if.h
+++ b/drivers/xen/vgt/vgt-if.h
@@ -233,7 +233,7 @@ static inline void vgt_exit(int cpu)
 #define XEN_IGD_MAX     3   /* the max GEN dev type supported */
 
 /* from "include/xen/interface/xen.h" */
-typedef uint16_t domid_t;
+/*typedef uint16_t domid_t;*/
 
 static inline bool kvm_guest_domain(void)
 {


### PR DESCRIPTION
fix "error: redefinition of typedef ‘domid_t’"

full log:

In file included from drivers/xen/vgt/vgt.h:45,
                 from arch/x86/kvm/../../../virt/kvm/vgt_helper.c:12:
drivers/xen/vgt/vgt-if.h:236: error: redefinition of typedef ‘domid_t’
include/xen/interface/xen.h:239: note: previous declaration of ‘domid_t’ was here
make[2]: **\* [arch/x86/kvm/../../../virt/kvm/vgt_helper.o] Error 1
make[1]: **\* [arch/x86/kvm] Error 2
make: **\* [arch/x86] Error 2
